### PR TITLE
fixed double reset on array and non-compatible type hint

### DIFF
--- a/lib/PHPTracker/Bencode/Value/Container.php
+++ b/lib/PHPTracker/Bencode/Value/Container.php
@@ -15,8 +15,12 @@ abstract class PHPTracker_Bencode_Value_Container extends PHPTracker_Bencode_Val
      *
      * @param array $value
      */
-    public function __construct( array $value = null )
+    public function __construct( $value = null )
     {
+ 	if( !is_array( $value ) ){	    
+	    exit( "Fatal Error: Argument 1 must be an array" );
+	}
+
         $this->value = array();
 
         if ( !isset( $value ) )

--- a/lib/PHPTracker/Torrent.php
+++ b/lib/PHPTracker/Torrent.php
@@ -216,7 +216,7 @@ class PHPTracker_Torrent
                 'name'          => $this->__get( 'name' ),
                 'length'        => $this->__get( 'length' ),
             ),
-            'announce'          => reset( reset( $announce_list ) ),
+            'announce'          => reset( $announce_list ),
             'announce-list'     => $announce_list,
         );
 


### PR DESCRIPTION
I added testing for array , if it's not an array exit with error message.